### PR TITLE
fixes ModuleNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-import os
 from setuptools import setup, find_packages
+import os
+
 abs_path = os.path.dirname(os.path.abspath(__file__))
 
 setup(
@@ -9,7 +10,7 @@ setup(
     description="onnx to keras/tensorflow lite",
     long_description=open(os.path.join(abs_path, "readme.md")).read(),
     long_description_content_type='text/markdown',
-    packages=find_packages(include=['onnx2tflite']),
+    packages=find_packages(include=['onnx2tflite', 'onnx2tflite.*']),
     license="Apache-2.0",
     platforms=["Windows", "linux"],
     install_requires=open(os.path.join(abs_path, "requirements.txt")).read().splitlines()


### PR DESCRIPTION
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-3-20765d978c1f> in <cell line: 0>()
----> 1 from onnx2tflite import onnx_converter

1 frames
/usr/local/lib/python3.11/dist-packages/onnx2tflite-2.0-py3.11.egg/onnx2tflite/converter.py in <module>
      1 import os
      2 import logging
----> 3 from .components import load_onnx_modelproto, keras_builder, tflite_builder, get_elements_error
      4 
      5 logging.basicConfig(level=logging.INFO)

ModuleNotFoundError: No module named 'onnx2tflite.components'
